### PR TITLE
#type: ignore for matplotlib

### DIFF
--- a/src/axiomatic/axtract.py
+++ b/src/axiomatic/axtract.py
@@ -1,8 +1,8 @@
-import ipywidgets as widgets  # type: ignore
-from IPython.display import display, Math, HTML  # type: ignore
+import ipywidgets as widgets # type: ignore
+from IPython.display import display, Math, HTML # type: ignore
 from dataclasses import dataclass, field
 import hypernetx as hnx # type: ignore
-import matplotlib.pyplot as plt
+import matplotlib.pyplot as plt # type: ignore
 import re
 
 OPTION_LIST = {


### PR DESCRIPTION
added #type: ignore to matplot lib in axtract.py because CI compilation failed