### PR TITLE
Plot interactive spectra return fig

### DIFF
--- a/src/axiomatic/pic_helpers.py
+++ b/src/axiomatic/pic_helpers.py
@@ -194,7 +194,7 @@ def plot_interactive_spectra(
         yaxis=dict(range=[y_min, y_max]),
     )
 
-    fig.show()
+    return fig
 
 
 def plot_parameter_history(parameters: List[Parameter], parameter_history: List[dict]):


### PR DESCRIPTION
Return fig instead od just showing it, to be able tu manipulate it later (particularly, useful to get the HTML for the playground extension)